### PR TITLE
Loosen dependencies so that it's easier to librarian-puppet update.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,8 +7,8 @@
   "source": "https://github.com/silverstripe/puppet-servicetools",
   "dependencies": [
     {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 0.4.0 < 3.0.0"
+      "name": "puppet/systemd",
+      "version_requirement": ">= 0.4.0"
     }
   ],
   "project_page": "https://github.com/silverstripe/puppet-servicetools",


### PR DESCRIPTION
This module isn't really affected by a lot of major upstream updates, so
pinning majors is overly cautions in this ecosystem.